### PR TITLE
Failing test and some cmake magic to compile multiple targets and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .idea
 cmake-build-debug
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Debug
+boost_test.build
+boost_test.xcodeproj
+cmake_install.cmake

--- a/Boost.SafeFloat/fail_test_1_cpp_17.cpp
+++ b/Boost.SafeFloat/fail_test_1_cpp_17.cpp
@@ -1,0 +1,5 @@
+#include "competency-test-cpp17.hpp"
+int main(){
+    using namespace test::literal;
+    0.3_sf; //expected to fail compilation
+}

--- a/Boost.SafeFloat/test-cpp17.cpp
+++ b/Boost.SafeFloat/test-cpp17.cpp
@@ -57,6 +57,8 @@ void test_floating_literal()
     static_assert(0.5_sf == 0.5f, "Problem");
     static_assert(0.25_sf == 0.25f, "Problem");
     static_assert(.03125_sd == .03125, "Problem");
+    static_assert(1_sf == 1f, "Problem");
+    static_assert(2_sf == 2f, "Problem");
     static_assert(62.5e-3_sld == 62.5e-3l, "Problem");
     static_assert(9.5367431640625e-07_sd == 9.5367431640625e-07, "Problem");
     static_assert(125.e-3_sf == 125.e-3f, "Problem");
@@ -64,6 +66,7 @@ void test_floating_literal()
     static_assert(0x1p-1_sf == 0x1p-1f, "Problem");
     static_assert(0x8.0p-98_sd == 0x8.0p-98, "Problem");
     static_assert(0x.00004p+3_sld == 0x.00004p+3l, "Problem");
+    
     
     // Shouldn't compile
     //3_sf;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,23 @@
 project(boost_test)
-set(CMAKE_CXX_STANDARD 11)
-add_executable(boost_test main.cpp Boost.SafeFloat/test-cpp11.cpp)
+cmake_minimum_required(VERSION 3.10)
+include(CheckCXXCompilerFlag)
+
+#Headers in project file
+add_executable(test_headers Boost.SafeFloat)
+set_target_properties(test_headers PROPERTIES
+EXCLUDE_FROM_ALL TRUE
+EXCLUDE_FROM_DEFAULT_BUILD TRUE
+LINKER_LANGUAGE CXX)
+
+#Executable for C++17/1z
+add_executable(boost_test_17 main.cpp Boost.SafeFloat/test-cpp17.cpp)
+check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
+if(HAVE_FLAG_STD_CXX17)
+set_target_properties(boost_test_17 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++17")
+else()
+set_target_properties(boost_test_17 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++1z")
+endif()
+
+#Executable for C++11
+add_executable(boost_test_11 main.cpp Boost.SafeFloat/test-cpp11.cpp)
+set_target_properties(boost_test_11 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(boost_test)
 cmake_minimum_required(VERSION 3.10)
 include(CheckCXXCompilerFlag)
 
+include_directories(Boost.SafeFloat)
+
 #Headers in project file
 add_executable(test_headers Boost.SafeFloat)
 set_target_properties(test_headers PROPERTIES
@@ -10,7 +12,7 @@ EXCLUDE_FROM_DEFAULT_BUILD TRUE
 LINKER_LANGUAGE CXX)
 
 #Executable for C++17/1z
-add_executable(boost_test_17 main.cpp Boost.SafeFloat/test-cpp17.cpp)
+add_executable(boost_test_17 main17.cpp Boost.SafeFloat/test-cpp17.cpp)
 check_cxx_compiler_flag(-std=c++17 HAVE_FLAG_STD_CXX17)
 if(HAVE_FLAG_STD_CXX17)
 set_target_properties(boost_test_17 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++17")
@@ -19,5 +21,27 @@ set_target_properties(boost_test_17 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS}
 endif()
 
 #Executable for C++11
-add_executable(boost_test_11 main.cpp Boost.SafeFloat/test-cpp11.cpp)
+add_executable(boost_test_11 main11.cpp Boost.SafeFloat/test-cpp11.cpp)
 set_target_properties(boost_test_11 PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++11")
+
+enable_testing()
+# Tests that should fail compilation
+FILE(GLOB TestCompileFailSources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} Boost.SafeFloat/fail_test*.cpp)
+foreach(testCmpFailSrc ${TestCompileFailSources})
+        get_filename_component(testCmpFailName ${testCmpFailSrc} NAME_WE)
+        add_executable(${testCmpFailName} ${testCmpFailSrc})
+        set_target_properties(${testCmpFailName} PROPERTIES
+                              EXCLUDE_FROM_ALL TRUE
+                              EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+	if(HAVE_FLAG_STD_CXX17)
+	set_target_properties(${testCmpFailName} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++17")
+	else()
+	set_target_properties(${testCmpFailName} PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -pedantic --std=c++1z")
+	endif()
+
+        add_test(NAME ${testCmpFailName}
+                 COMMAND ${CMAKE_COMMAND} --build . --target ${testCmpFailName}
+                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+        set_tests_properties(${testCmpFailName} PROPERTIES WILL_FAIL TRUE)
+endforeach(testCmpFailSrc)

--- a/main11.cpp
+++ b/main11.cpp
@@ -1,5 +1,4 @@
-#include "Boost.SafeFloat/test-cpp11.hpp"
-//#include "Boost.SafeFloat/test-cpp17.hpp" 
+#include "Boost.SafeFloat/test-cpp11.hpp" 
 
 int main()
 {    

--- a/main17.cpp
+++ b/main17.cpp
@@ -1,0 +1,10 @@
+#include "Boost.SafeFloat/test-cpp17.hpp" 
+
+int main()
+{    
+    test_floating_literal();
+    test_vectorize();
+    test_get_vector();
+
+    return 0;
+}


### PR DESCRIPTION
Hi Tom, 
I checked your code. 
Your solution is very nice, there is a few missed cases and minor details (as always, thats why we code review things for). 
You can also use this test for the Real if you prefer to go that way.
In this PR, I added:
- Some Cmake stuff so you don't have to comment/uncomment lines to test.
- Some Cmake stuff to make a test that checks the compilation fails for numbers that will not be parseable.
- An assert of  a number that should be parseable, but failed to. "2_sf". 
- This website is a good resource to check what is valid and what is not: https://www.h-schmidt.net/FloatConverter/IEEE754.html
- In general, integer numbers are good, but don't worry for any of this now, we can handle all special cases after GSOC starts. Just sending the PR if you want to play around a little. 
A minor comment, try to use "size_t" in place of "unsigned int" when dealing with dimensions for vectors.



